### PR TITLE
Remove kotlinCompilerExtensionVersion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/.kotlin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,9 +71,6 @@ android {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/feature/permissions/build.gradle.kts
+++ b/feature/permissions/build.gradle.kts
@@ -45,9 +45,6 @@ android {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    }
 }
 
 dependencies {

--- a/feature/postcapture/build.gradle.kts
+++ b/feature/postcapture/build.gradle.kts
@@ -53,9 +53,6 @@ android {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    }
 
     @Suppress("UnstableApiUsage")
     testOptions {

--- a/feature/preview/build.gradle.kts
+++ b/feature/preview/build.gradle.kts
@@ -53,9 +53,6 @@ android {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    }
 
     @Suppress("UnstableApiUsage")
     testOptions {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -53,9 +53,6 @@ android {
         buildConfig = true
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    }
 
     @Suppress("UnstableApiUsage")
     testOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ compileSdk = "35"
 orchestrator = "1.5.1"
 minSdk = "21"
 targetSdk = "35"
-composeCompiler = "1.5.14"
 
 # Used below in dependency definitions
 # Compose and Accompanist versions are linked


### PR DESCRIPTION
In the #338, the Kotlin version was updated to 2.0.0+

Now, `kotlinCompilerExtensionVersion` was managed by Compose Compiler Gradle Plugin. 
https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility

You can remove `kotlinCompilerExtensionVersion`

And you can also see this blog to get more information.
`Jetpack Compose compiler moving to the Kotlin repository`
https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html